### PR TITLE
build(deps-dev): bump the dev-deps group across 1 directory with 11 u…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,26 +28,26 @@
     "bootstrap": "^5.3.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.0",
+    "@babel/core": "^7.26.9",
     "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/plugin-transform-private-methods": "^7.25.9",
-    "@babel/preset-env": "^7.26.0",
-    "@commitlint/cli": "^19.6.0",
-    "@commitlint/config-conventional": "^19.6.0",
+    "@babel/preset-env": "^7.26.9",
+    "@commitlint/cli": "^19.7.1",
+    "@commitlint/config-conventional": "^19.7.1",
     "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/exec": "^6.0.3",
+    "@semantic-release/exec": "^7.0.3",
     "@semantic-release/git": "^10.0.1",
-    "concurrently": "^9.1.0",
+    "concurrently": "^9.1.2",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "husky": "^9.1.7",
     "purgecss": "^7.0.2",
-    "rollup": "^4.27.4",
-    "semantic-release": "^24.2.0",
-    "stylelint": "^16.10.0",
-    "stylelint-config-standard-scss": "^13.1.0"
+    "rollup": "^4.34.8",
+    "semantic-release": "^24.2.3",
+    "stylelint": "^16.14.1",
+    "stylelint-config-standard-scss": "^14.0.0"
   },
   "prettier": {
     "trailingComma": "none"


### PR DESCRIPTION
…pdates

Updates the requirements on [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core), [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env), [@commitlint/cli](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/cli), [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/config-conventional), [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/HEAD/packages/node-resolve), [@semantic-release/exec](https://github.com/semantic-release/exec), [concurrently](https://github.com/open-cli-tools/concurrently), [rollup](https://github.com/rollup/rollup), [semantic-release](https://github.com/semantic-release/semantic-release), [stylelint](https://github.com/stylelint/stylelint) and [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) to permit the latest version.

Updates `@babel/core` to 7.26.9
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.26.9/packages/babel-core)

Updates `@babel/preset-env` to 7.26.9
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.26.9/packages/babel-preset-env)

Updates `@commitlint/cli` to 19.7.1
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.7.1/@commitlint/cli)

Updates `@commitlint/config-conventional` to 19.7.1
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/config-conventional/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.7.1/@commitlint/config-conventional)

Updates `@rollup/plugin-node-resolve` from 15.3.1 to 16.0.0
- [Changelog](https://github.com/rollup/plugins/blob/master/packages/node-resolve/CHANGELOG.md)
- [Commits](https://github.com/rollup/plugins/commits/commonjs-v16.0.0/packages/node-resolve)

Updates `@semantic-release/exec` from 6.0.3 to 7.0.3
- [Release notes](https://github.com/semantic-release/exec/releases)
- [Commits](https://github.com/semantic-release/exec/compare/v6.0.3...v7.0.3)

Updates `concurrently` to 9.1.2
- [Release notes](https://github.com/open-cli-tools/concurrently/releases)
- [Commits](https://github.com/open-cli-tools/concurrently/compare/v9.1.0...v9.1.2)

Updates `rollup` to 4.34.8
- [Release notes](https://github.com/rollup/rollup/releases)
- [Changelog](https://github.com/rollup/rollup/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rollup/rollup/compare/v4.27.4...v4.34.8)

Updates `semantic-release` to 24.2.3
- [Release notes](https://github.com/semantic-release/semantic-release/releases)
- [Commits](https://github.com/semantic-release/semantic-release/compare/v24.2.0...v24.2.3)

Updates `stylelint` to 16.14.1
- [Release notes](https://github.com/stylelint/stylelint/releases)
- [Changelog](https://github.com/stylelint/stylelint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/stylelint/stylelint/compare/16.10.0...16.14.1)

Updates `stylelint-config-standard-scss` from 13.1.0 to 14.0.0
- [Release notes](https://github.com/stylelint-scss/stylelint-config-standard-scss/releases)
- [Changelog](https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/stylelint-scss/stylelint-config-standard-scss/compare/v13.1.0...v14.0.0)

---
updated-dependencies:
- dependency-name: "@babel/core" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@babel/preset-env" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@commitlint/cli" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@commitlint/config-conventional" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@rollup/plugin-node-resolve" dependency-type: direct:development update-type: version-update:semver-major dependency-group: dev-deps
- dependency-name: "@semantic-release/exec" dependency-type: direct:development update-type: version-update:semver-major dependency-group: dev-deps
- dependency-name: concurrently dependency-type: direct:development dependency-group: dev-deps
- dependency-name: rollup dependency-type: direct:development dependency-group: dev-deps
- dependency-name: semantic-release dependency-type: direct:development dependency-group: dev-deps
- dependency-name: stylelint dependency-type: direct:development dependency-group: dev-deps
- dependency-name: stylelint-config-standard-scss dependency-type: direct:development update-type: version-update:semver-major dependency-group: dev-deps ...

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

## Additional context
<!-- e.g. Fixes #(issue) -->
